### PR TITLE
Added new ENV variable to configure cron schedule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY entrypoint.sh /blobsaver/
 
 RUN chmod +x /blobsaver/entrypoint.sh
 
-ENV VERSION=""
+ENV VERSION="" \
+    CRON_SCHEDULE="*/5 * * * *"
 
 ENTRYPOINT ["/blobsaver/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -12,20 +12,21 @@ The only purpose of this container is to automatically grab blobs in the backgro
 <b>You will need to already have a functional blobsaver.xml</b></br>
 Currently, this container does not have the ability to generate it automatically. There are ways to get this, mainly being to just see if your distro has a supported blobsaver package and generating it from that. Otherwise, if you already know the needed details for blob saving functionality with Blobsaver, you can just make the XML yourself.</br>
 
-By default, it will check every 5 minutes. You can change this by building it yourself and modifying the cron line. </br>
+By default, it will check every 5 minutes. You can change this by supplying an individual schedule expression for cron using the environment variable `CRON_SCHEDULE`. </br>
 
 Find a place to store your blobs. Something like `/home/(user)/Documents/Blobs/`. This will be needed later. </br>
 
 ### Docker container </br>
 ```
-docker run -d --name (container name) -v (path to blob directory):/blobsaver/blobs/ -e VERSION=(version) passivelemon/blobsaver-docker:latest
+docker run -d --name (container name) -v (path to blob directory):/blobsaver/blobs/ -e VERSION=(version) -e CRON_SCHEDULE=(schedule) passivelemon/blobsaver-docker:latest
 ```
 | Operator | Need | Details |
 |:-|:-|:-|
 | `-d` | Yes | will run the container in the background. |
 | `--name (container name)` | No | Sets the name of the container to the following word. You can change this to whatever you want. |
 | `-v (path to blob directory):/blobsaver/blobs/` | Yes | Sets the folder that holds your blobs and the xml. This should be the place you just chose. Make sure your `blobsaver.xml` is in this location. |
-| `-e VERSION=(version)` | Yes | Sets the version of Blobsaver that the container will download. Must be a supported version found on the Blobsaver. Use 3.5.0 at the minimum because that is when CLI functionality was added. |
+| `-e VERSION=(version)` | Yes | Sets the version of Blobsaver that the container will download. Must be a supported version found on the Blobsaver. Use `3.5.0` at the minimum because that is when CLI functionality was added. |
+| `-e CRON_SCHEDULE=(schedule)` | No | Configure how often Blobsaver should save your blobs. By default, it is `*/5 * * * *`. Check out [crontab.guru](https://crontab.guru/#*/5_*_*_*_*) for explanation of this value.  |
 | `passivelemon/blobsaver-docker:latest` | Yes | The repository on Docker hub. By default, it is the latest version that I have published. |
 
 #### Example:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,5 @@ if [ ! -e /opt/blobsaver/bin/blobsaver ]; then
 fi
 
 export BLOBSAVER_CLI_ONLY
-(crontab -l 2>/dev/null; echo "*/5 * * * * /opt/blobsaver/bin/blobsaver --import=/blobsaver/blobs/blobsaver.xml --save-path=/blobsaver/blobs --include-betas --background-autosave") | crontab -
+(crontab -l 2>/dev/null; echo "$CRON_SCHEDULE /opt/blobsaver/bin/blobsaver --import=/blobsaver/blobs/blobsaver.xml --save-path=/blobsaver/blobs --include-betas --background-autosave") | crontab -
 crond -f


### PR DESCRIPTION
Hi @PassiveLemon! 👋
First of all thanks for creating a Docker container for Blobsaver! 👍

I wanted to change the cron schedule and noticed your comment in the README.
> By default, it will check every 5 minutes. You can change this <ins>by building it yourself and modifying the cron line</ins>.

I did but thought it may be also useful for others. So I changed the bash script a little bit to use a new environment variable `CRON_SCHEDULE` which can be used to configure a different schedule if preferred.

I also updated the README to document this change.
If you want me to change anything else, feel free to edit the PR or feel free to ask me to do so. 🙂

Greetings!